### PR TITLE
Refactor UNO MCP architecture to Python FastMCP bridge

### DIFF
--- a/MidiMcpPlayer/MidiMcpPlayer.ino
+++ b/MidiMcpPlayer/MidiMcpPlayer.ino
@@ -92,6 +92,7 @@ void sendJsonError(WiFiClient &client, int statusCode, const String &code,
 void processClient(WiFiClient &client);
 void handleStatusRequest(WiFiClient &client);
 void handleSequencePost(WiFiClient &client, const String &body);
+void printWifiStatus();
 
 void beginPlayback();
 void stopPlayback(bool keepPending);
@@ -454,17 +455,15 @@ void setup() {
 
   Serial.println(F("Booting UNO R4 MIDI player"));
 
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-  Serial.print(F("Connecting to Wi-Fi"));
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
-    Serial.print('.');
+  int status = WL_IDLE_STATUS;
+  while (status != WL_CONNECTED) {
+    Serial.print(F("Attempting to connect to Network named: "));
+    Serial.println(WIFI_SSID);
+    status = WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    delay(10000);
   }
-  Serial.println();
-  Serial.print(F("Connected. IP: "));
-  Serial.println(WiFi.localIP());
-
   server.begin();
+  printWifiStatus();
   Serial.println(F("Sequence control server listening on port 80"));
 
   Serial1.begin(31250);
@@ -485,4 +484,19 @@ void loop() {
   if (client) {
     processClient(client);
   }
+}
+
+void printWifiStatus() {
+  Serial.print(F("SSID: "));
+  Serial.println(WiFi.SSID());
+
+  IPAddress ip = WiFi.localIP();
+  Serial.print(F("IP Address: "));
+  Serial.println(ip);
+
+  long rssi = WiFi.RSSI();
+  Serial.print(F("signal strength (RSSI):"));
+  Serial.print(rssi);
+  Serial.println(F(" dBm"));
+  Serial.println(ip);
 }

--- a/MidiMcpPlayer/MidiMcpPlayer.ino
+++ b/MidiMcpPlayer/MidiMcpPlayer.ino
@@ -1,0 +1,482 @@
+#include <WiFiS3.h>
+#include <ArduinoJson.h>
+#include <MIDI.h>
+
+// Replace with your Wi-Fi credentials
+const char *WIFI_SSID = "YOUR_WIFI_SSID";
+const char *WIFI_PASSWORD = "YOUR_WIFI_PASSWORD";
+
+const uint16_t CONTROL_PORT = 80;
+const uint8_t BUTTON_PIN = 4;       // D4 on Arduino UNO R4 WiFi
+const uint8_t DEFAULT_MIDI_CHANNEL = 1;
+const size_t MAX_EVENTS = 64;
+
+WiFiServer server(CONTROL_PORT);
+
+MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI);
+
+struct MusicEvent {
+  bool isNote;
+  uint8_t note;
+  uint8_t velocity;
+  uint16_t ticks;
+};
+
+struct MusicSequence {
+  MusicEvent events[MAX_EVENTS];
+  size_t count;
+  uint8_t channel;
+};
+
+MusicSequence sequence;
+bool sequenceLoaded = false;
+
+bool playing = false;
+bool startPending = false;
+bool midiRunning = false;
+
+size_t currentEventIndex = 0;
+uint16_t ticksRemaining = 0;
+bool noteActive = false;
+uint8_t activeNote = 0;
+uint8_t activeVelocity = 0;
+
+bool buttonState = HIGH;
+bool lastButtonReading = HIGH;
+unsigned long lastDebounceTime = 0;
+const unsigned long debounceDelay = 30;
+
+const uint8_t STATUS_OK = 200;
+const uint8_t STATUS_BAD_REQUEST = 400;
+const uint8_t STATUS_METHOD_NOT_ALLOWED = 405;
+const uint8_t STATUS_NOT_FOUND = 404;
+
+String statusText(int code) {
+  switch (code) {
+    case STATUS_OK:
+      return "OK";
+    case STATUS_BAD_REQUEST:
+      return "Bad Request";
+    case STATUS_METHOD_NOT_ALLOWED:
+      return "Method Not Allowed";
+    case STATUS_NOT_FOUND:
+      return "Not Found";
+    default:
+      return "Internal Server Error";
+  }
+}
+
+void sendJsonResponse(WiFiClient &client, int statusCode, const JsonDocument &doc) {
+  client.print(F("HTTP/1.1 "));
+  client.print(statusCode);
+  client.print(' ');
+  client.println(statusText(statusCode));
+  client.println(F("Content-Type: application/json"));
+  client.print(F("Content-Length: "));
+  client.println(measureJson(doc));
+  client.println(F("Connection: close"));
+  client.println();
+  serializeJson(doc, client);
+}
+
+void sendJsonError(WiFiClient &client, int statusCode, const String &code,
+                   const String &message) {
+  StaticJsonDocument<256> doc;
+  JsonObject error = doc.createNestedObject("error");
+  error["code"] = code;
+  error["message"] = message;
+  sendJsonResponse(client, statusCode, doc);
+}
+
+void processClient(WiFiClient &client);
+void handleStatusRequest(WiFiClient &client);
+void handleSequencePost(WiFiClient &client, const String &body);
+
+void beginPlayback();
+void stopPlayback(bool keepPending);
+void startCurrentEvent();
+void finishCurrentEvent();
+void allNotesOff();
+void handleButton();
+
+void handleMidiClock();
+void handleMidiStart();
+void handleMidiStop();
+void handleMidiContinue();
+
+void processClient(WiFiClient &client) {
+  client.setTimeout(2000);
+
+  String requestLine = client.readStringUntil('\r');
+  client.read();  // consume '\n'
+  if (requestLine.length() == 0) {
+    client.stop();
+    return;
+  }
+
+  int firstSpace = requestLine.indexOf(' ');
+  int secondSpace = requestLine.indexOf(' ', firstSpace + 1);
+  if (firstSpace < 0 || secondSpace < 0) {
+    sendJsonError(client, STATUS_BAD_REQUEST, "malformed_request",
+                  "Unable to parse HTTP request line.");
+    client.stop();
+    return;
+  }
+
+  String method = requestLine.substring(0, firstSpace);
+  String path = requestLine.substring(firstSpace + 1, secondSpace);
+
+  int contentLength = 0;
+  bool isJson = false;
+  while (client.connected()) {
+    String line = client.readStringUntil('\r');
+    client.read();
+    if (line.length() == 0) {
+      break;
+    }
+    line.trim();
+    if (line.startsWith(F("Content-Length:"))) {
+      contentLength = line.substring(15).toInt();
+    } else if (line.startsWith(F("Content-Type:"))) {
+      if (line.indexOf(F("application/json")) >= 0) {
+        isJson = true;
+      }
+    }
+  }
+
+  if (method == "POST" && path == "/sequence") {
+    if (!isJson) {
+      sendJsonError(client, STATUS_BAD_REQUEST, "content_type_json_required",
+                    "POST /sequence expects application/json.");
+      client.stop();
+      return;
+    }
+
+    if (contentLength <= 0) {
+      sendJsonError(client, STATUS_BAD_REQUEST, "content_length_required",
+                    "Missing Content-Length header.");
+      client.stop();
+      return;
+    }
+
+    String body;
+    body.reserve(contentLength);
+    while (body.length() < (unsigned)contentLength && client.connected()) {
+      if (client.available()) {
+        body += static_cast<char>(client.read());
+      }
+    }
+
+    handleSequencePost(client, body);
+  } else if (method == "GET" && path == "/status") {
+    handleStatusRequest(client);
+  } else if (method == "POST") {
+    sendJsonError(client, STATUS_NOT_FOUND, "unknown_endpoint",
+                  String("No handler for ") + path + ".");
+  } else {
+    sendJsonError(client, STATUS_METHOD_NOT_ALLOWED, "method_not_allowed",
+                  "Only POST /sequence and GET /status are supported.");
+  }
+
+  client.stop();
+}
+
+void handleStatusRequest(WiFiClient &client) {
+  StaticJsonDocument<256> doc;
+  doc["sequenceLoaded"] = sequenceLoaded;
+  doc["eventCount"] = sequence.count;
+  doc["channel"] = sequence.channel == 0 ? DEFAULT_MIDI_CHANNEL : sequence.channel;
+  doc["playing"] = playing;
+  doc["startPending"] = startPending;
+  doc["midiClockRunning"] = midiRunning;
+
+  JsonObject wifi = doc.createNestedObject("wifi");
+  wifi["ip"] = WiFi.localIP().toString();
+  wifi["rssi"] = WiFi.RSSI();
+
+  sendJsonResponse(client, STATUS_OK, doc);
+}
+
+void handleSequencePost(WiFiClient &client, const String &body) {
+  StaticJsonDocument<4096> doc;
+  DeserializationError err = deserializeJson(doc, body);
+  if (err) {
+    sendJsonError(client, STATUS_BAD_REQUEST, "invalid_json",
+                  String("Unable to parse JSON body: ") + err.c_str());
+    return;
+  }
+
+  JsonObject payload = doc.as<JsonObject>();
+  JsonArray seqArray = payload["sequence"].as<JsonArray>();
+  if (seqArray.isNull() || seqArray.size() == 0) {
+    sendJsonError(client, STATUS_BAD_REQUEST, "sequence_required",
+                  "Payload must include a non-empty 'sequence' array.");
+    return;
+  }
+
+  uint8_t channel = payload["channel"].as<uint8_t>();
+  if (channel < 1 || channel > 16) {
+    channel = DEFAULT_MIDI_CHANNEL;
+  }
+
+  size_t count = 0;
+  for (JsonObject obj : seqArray) {
+    if (count >= MAX_EVENTS) {
+      sendJsonError(client, STATUS_BAD_REQUEST, "sequence_too_long",
+                    String("Sequence can contain at most ") + MAX_EVENTS + " events.");
+      return;
+    }
+
+    const char *type = obj["type"] | "";
+    uint16_t ticks = obj["ticks"].as<uint16_t>();
+    if (ticks == 0) {
+      sendJsonError(client, STATUS_BAD_REQUEST, "ticks_must_be_positive",
+                    "Each event must specify 'ticks' greater than zero.");
+      return;
+    }
+
+    MusicEvent &event = sequence.events[count];
+    event.ticks = ticks;
+
+    if (strcmp(type, "note") == 0) {
+      int note = obj["note"].as<int>();
+      if (note < 0 || note > 127) {
+        sendJsonError(client, STATUS_BAD_REQUEST, "note_out_of_range",
+                      "Note values must be between 0 and 127.");
+        return;
+      }
+      int velocity = obj["velocity"].as<int>();
+      if (velocity < 1 || velocity > 127) {
+        velocity = 100;
+      }
+      event.isNote = true;
+      event.note = static_cast<uint8_t>(note);
+      event.velocity = static_cast<uint8_t>(velocity);
+    } else if (strcmp(type, "rest") == 0) {
+      event.isNote = false;
+      event.note = 0;
+      event.velocity = 0;
+    } else {
+      sendJsonError(client, STATUS_BAD_REQUEST, "invalid_event_type",
+                    "Each event 'type' must be 'note' or 'rest'.");
+      return;
+    }
+    count++;
+  }
+
+  sequence.count = count;
+  sequence.channel = channel;
+  sequenceLoaded = count > 0;
+  startPending = false;
+  if (playing) {
+    stopPlayback(false);
+  }
+
+  Serial.print(F("Loaded sequence with "));
+  Serial.print(count);
+  Serial.print(F(" events on channel "));
+  Serial.println(channel);
+
+  StaticJsonDocument<256> response;
+  response["status"] = "ok";
+  response["eventsLoaded"] = count;
+  response["channel"] = channel;
+  response["sequenceLoaded"] = sequenceLoaded;
+  response["midiClockRunning"] = midiRunning;
+
+  sendJsonResponse(client, STATUS_OK, response);
+}
+
+void beginPlayback() {
+  if (!sequenceLoaded || sequence.count == 0) {
+    startPending = false;
+    return;
+  }
+
+  currentEventIndex = 0;
+  ticksRemaining = 0;
+  noteActive = false;
+  playing = true;
+  startPending = false;
+  startCurrentEvent();
+  Serial.println(F("Playback started."));
+}
+
+void stopPlayback(bool keepPending) {
+  if (noteActive) {
+    MIDI.sendNoteOff(activeNote, 0,
+                     sequence.channel == 0 ? DEFAULT_MIDI_CHANNEL : sequence.channel);
+    noteActive = false;
+  }
+  playing = false;
+  ticksRemaining = 0;
+  currentEventIndex = 0;
+  if (!keepPending) {
+    startPending = false;
+  }
+  Serial.println(F("Playback stopped."));
+}
+
+void startCurrentEvent() {
+  if (!playing || currentEventIndex >= sequence.count) {
+    stopPlayback(false);
+    return;
+  }
+
+  MusicEvent &event = sequence.events[currentEventIndex];
+  ticksRemaining = event.ticks;
+  if (event.isNote) {
+    uint8_t channel = sequence.channel == 0 ? DEFAULT_MIDI_CHANNEL : sequence.channel;
+    MIDI.sendNoteOn(event.note, event.velocity, channel);
+    noteActive = true;
+    activeNote = event.note;
+    activeVelocity = event.velocity;
+  } else {
+    noteActive = false;
+  }
+}
+
+void finishCurrentEvent() {
+  if (noteActive) {
+    uint8_t channel = sequence.channel == 0 ? DEFAULT_MIDI_CHANNEL : sequence.channel;
+    MIDI.sendNoteOff(activeNote, 0, channel);
+    noteActive = false;
+  }
+  currentEventIndex++;
+  if (currentEventIndex >= sequence.count) {
+    stopPlayback(false);
+  } else {
+    startCurrentEvent();
+  }
+}
+
+void allNotesOff() {
+  uint8_t channel = sequence.channel == 0 ? DEFAULT_MIDI_CHANNEL : sequence.channel;
+  for (uint8_t note = 0; note < 128; ++note) {
+    MIDI.sendNoteOff(note, 0, channel);
+  }
+}
+
+void handleButton() {
+  bool reading = digitalRead(BUTTON_PIN);
+  if (reading != lastButtonReading) {
+    lastDebounceTime = millis();
+  }
+
+  if ((millis() - lastDebounceTime) > debounceDelay) {
+    if (reading != buttonState) {
+      buttonState = reading;
+      if (buttonState == LOW) {
+        if (playing || startPending) {
+          stopPlayback(false);
+        } else if (sequenceLoaded) {
+          startPending = true;
+          if (midiRunning) {
+            beginPlayback();
+          }
+        } else {
+          Serial.println(F("No sequence loaded."));
+        }
+      }
+    }
+  }
+
+  lastButtonReading = reading;
+}
+
+void handleMidiClock() {
+  if (!midiRunning) {
+    return;
+  }
+
+  if (startPending && !playing && sequenceLoaded) {
+    beginPlayback();
+  }
+
+  if (!playing) {
+    return;
+  }
+
+  if (ticksRemaining > 0) {
+    ticksRemaining--;
+    if (ticksRemaining == 0) {
+      finishCurrentEvent();
+    }
+  }
+}
+
+void handleMidiStart() {
+  midiRunning = true;
+  Serial.println(F("MIDI Start received."));
+  bool wasPlaying = playing;
+  if (playing) {
+    stopPlayback(true);
+  }
+  if (wasPlaying) {
+    startPending = true;
+  }
+  if (startPending && sequenceLoaded) {
+    beginPlayback();
+  }
+}
+
+void handleMidiStop() {
+  midiRunning = false;
+  Serial.println(F("MIDI Stop received."));
+  if (playing) {
+    stopPlayback(true);
+  }
+}
+
+void handleMidiContinue() {
+  midiRunning = true;
+  Serial.println(F("MIDI Continue received."));
+  if (startPending && sequenceLoaded) {
+    beginPlayback();
+  }
+}
+
+void setup() {
+  sequence.count = 0;
+  sequence.channel = DEFAULT_MIDI_CHANNEL;
+
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+  Serial.begin(115200);
+  while (!Serial) {
+  }
+
+  Serial.println(F("Booting UNO R4 MIDI player"));
+
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  Serial.print(F("Connecting to Wi-Fi"));
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print('.');
+  }
+  Serial.println();
+  Serial.print(F("Connected. IP: "));
+  Serial.println(WiFi.localIP());
+
+  server.begin();
+  Serial.println(F("Sequence control server listening on port 80"));
+
+  Serial1.begin(31250);
+  MIDI.begin(MIDI_CHANNEL_OMNI);
+  MIDI.turnThruOff();
+
+  MIDI.setHandleClock(handleMidiClock);
+  MIDI.setHandleStart(handleMidiStart);
+  MIDI.setHandleStop(handleMidiStop);
+  MIDI.setHandleContinue(handleMidiContinue);
+}
+
+void loop() {
+  handleButton();
+  MIDI.read();
+
+  WiFiClient client = server.available();
+  if (client) {
+    processClient(client);
+  }
+}

--- a/MidiMcpPlayer/MidiMcpPlayer.ino
+++ b/MidiMcpPlayer/MidiMcpPlayer.ino
@@ -490,11 +490,24 @@ void finishCurrentEvent() {
     MIDI.sendNoteOff(activeNote, 0, channel);
     noteActive = false;
   }
+  if (!playing) {
+    return;
+  }
+
   currentEventIndex++;
   if (currentEventIndex >= sequence.count) {
-    stopPlayback(false);
-  } else {
+    currentEventIndex = 0;
+    if (sequence.count == 0) {
+      stopPlayback(false);
+      return;
+    }
+    Serial.println(F("Looping sequence."));
+  }
+
+  if (sequence.count > 0) {
     startCurrentEvent();
+  } else {
+    stopPlayback(false);
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ LLM / Claude ──(MCP over stdio)──▶ `uno_r4_mcp_bridge.py`
 
 The Arduino receives monophonic MIDI phrases, waits for an external MIDI clock
 (start/continue/stop), and performs the uploaded material in sync. Transport
-is handled with a push button on D4 that toggles between play and stop.
+is handled with a push button on D4 that toggles between play and stop, while a
+second button on D3 can be tapped to fire a middle C over MIDI for quick
+testing.
 
 ## Components
 
@@ -33,8 +35,9 @@ is handled with a push button on D4 that toggles between play and stop.
    Arduino IDE.
 2. Open `MidiMcpPlayer/MidiMcpPlayer.ino` and set `WIFI_SSID` / `WIFI_PASSWORD`
    near the top of the file.
-3. Wire the MIDI shield to the hardware UART and a normally-open push button
-   from D4 to ground (the sketch enables the pull-up resistor).
+3. Wire the MIDI shield to the hardware UART, a normally-open push button from
+   D4 to ground (transport control), and another normally-open push button from
+   D3 to ground (manual C trigger). The sketch enables the pull-up resistors.
 4. Select **Arduino UNO R4 WiFi** as the target board and upload the sketch.
 5. Open the serial monitor at 115200 baud to confirm the assigned IP address and
    REST server status.
@@ -173,7 +176,8 @@ configuration, restart Claude Desktop. The MCP panel should list
    calling `get_status` (either from Claude or via `mcp` CLI tooling).
 3. Have the AI agent invoke `load_sequence` with the desired phrase.
 4. Press the D4 button to arm playback. Once external MIDI clock pulses arrive,
-   the UNO will perform the uploaded notes in sync. Press D4 again to stop.
+   the UNO will perform the uploaded notes in sync. Press D4 again to stop. Tap
+   the D3 button at any time to send a momentary middle C for monitoring.
 5. Send a new `load_sequence` request whenever you want to change the material.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ LLM / Claude ──(MCP over stdio)──▶ `uno_r4_mcp_bridge.py`
 
 The Arduino receives monophonic MIDI phrases, waits for an external MIDI clock
 (start/continue/stop), and performs the uploaded material in sync. Transport
-is handled with a push button on D4 that toggles between play and stop, while a
-second button on D3 can be tapped to fire a middle C over MIDI for quick
-testing.
+is handled with a push button on D4 that toggles between play and stop and the
+sequence loops continuously until you press D4 again. A second button on D3 can
+be tapped to fire a middle C over MIDI for quick testing.
 
 ## Components
 
@@ -60,7 +60,9 @@ testing.
   events must include `note` (0–127) and optionally `velocity` (defaults to 100).
   Use the optional `ticksPerQuarter` (alias `ppqn`) to tell the sketch what
   resolution the payload uses; it is scaled to 24 ticks per quarter internally.
-  The board immediately replaces the previous buffer and arms playback.
+  The board immediately replaces the previous buffer and arms playback. Once
+  started, the buffer loops indefinitely until you stop transport with the D4
+  button or an external MIDI Stop.
 
 - `GET /status`
   ```json
@@ -176,8 +178,9 @@ configuration, restart Claude Desktop. The MCP panel should list
    calling `get_status` (either from Claude or via `mcp` CLI tooling).
 3. Have the AI agent invoke `load_sequence` with the desired phrase.
 4. Press the D4 button to arm playback. Once external MIDI clock pulses arrive,
-   the UNO will perform the uploaded notes in sync. Press D4 again to stop. Tap
-   the D3 button at any time to send a momentary middle C for monitoring.
+   the UNO will perform the uploaded notes in sync and keep looping the buffered
+   sequence. Press D4 again to stop. Tap the D3 button at any time to send a
+   momentary middle C for monitoring.
 5. Send a new `load_sequence` request whenever you want to change the material.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,0 +1,168 @@
+# UNO R4 WiFi MIDI MCP Bridge
+
+This project pairs an Arduino UNO R4 WiFi sketch with a Python-based
+[FastMCP](https://github.com/jlowin/fastmcp) server. The Arduino stays on your
+network listening for HTTP commands, while the Python program exposes a
+Model Context Protocol (MCP) interface that tools such as Claude Desktop can
+use to load MIDI sequences and monitor playback.
+
+```
+LLM / Claude ──(MCP over stdio)──▶ `uno_r4_mcp_bridge.py`
+                             │
+                             └──(HTTP)──▶ Arduino UNO R4 WiFi
+```
+
+The Arduino receives monophonic MIDI phrases, waits for an external MIDI clock
+(start/continue/stop), and performs the uploaded material in sync. Transport
+is handled with a push button on D4 that toggles between play and stop.
+
+## Components
+
+- **Arduino sketch (`MidiMcpPlayer/MidiMcpPlayer.ino`)** – connects to Wi-Fi,
+  exposes a tiny REST API, buffers MIDI events, and performs them according to
+  incoming MIDI clock messages. The hardware UART (`Serial1`) is used for the
+  MIDI shield.
+- **Python bridge (`uno_r4_mcp_bridge.py`)** – implements a FastMCP server with
+  two tools: `load_sequence` uploads note data to the Arduino and `get_status`
+  reads back transport information. The bridge is designed to run on the same
+  machine as the LLM client.
+
+## Arduino setup
+
+1. Install the **WiFiS3**, **ArduinoJson**, and **MIDI Library** packages in the
+   Arduino IDE.
+2. Open `MidiMcpPlayer/MidiMcpPlayer.ino` and set `WIFI_SSID` / `WIFI_PASSWORD`
+   near the top of the file.
+3. Wire the MIDI shield to the hardware UART and a normally-open push button
+   from D4 to ground (the sketch enables the pull-up resistor).
+4. Select **Arduino UNO R4 WiFi** as the target board and upload the sketch.
+5. Open the serial monitor at 115200 baud to confirm the assigned IP address and
+   REST server status.
+
+### REST endpoints exposed by the Arduino
+
+- `POST /sequence`
+  ```json
+  {
+    "channel": 1,
+    "sequence": [
+      { "type": "note", "note": 60, "velocity": 96, "ticks": 24 },
+      { "type": "rest", "ticks": 12 },
+      { "type": "note", "note": 64, "velocity": 96, "ticks": 24 }
+    ]
+  }
+  ```
+  Loads up to 64 events. Each event requires a positive `ticks` duration. Note
+  events must include `note` (0–127) and optionally `velocity` (defaults to 100).
+  The board immediately replaces the previous buffer and arms playback.
+
+- `GET /status`
+  ```json
+  {
+    "sequenceLoaded": true,
+    "eventCount": 3,
+    "channel": 1,
+    "playing": false,
+    "startPending": true,
+    "midiClockRunning": false,
+    "wifi": {
+      "ip": "192.168.1.42",
+      "rssi": -54
+    }
+  }
+  ```
+  Useful for debugging connectivity from the Python side.
+
+## Python MCP bridge
+
+Create a virtual environment (recommended) and install the dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+The bridge reads its configuration from CLI flags or environment variables. The
+most convenient approach is to create a `.env` file next to the script:
+
+```env
+UNO_R4_BASE_URL=http://192.168.1.42
+UNO_R4_TIMEOUT=5
+MCP_TRANSPORT=stdio
+```
+
+Then start the server (which defaults to stdio transport):
+
+```bash
+python uno_r4_mcp_bridge.py
+```
+
+Two MCP tools become available:
+
+- `load_sequence(sequence, channel=1)` – validates the payload and forwards it
+  to `POST /sequence` on the Arduino. On success the Arduino confirms how many
+  events were buffered and whether the MIDI clock is currently running.
+- `get_status()` – simply returns the JSON document from `GET /status`.
+
+Both tools surface Arduino-side validation errors (e.g. bad note numbers) back
+through MCP so the calling agent can correct its request.
+
+## Music data format
+
+- **ticks** – durations are specified in MIDI clock ticks (24 ticks per quarter
+  note when the external device conforms to the MIDI spec).
+- **note events** – require `type: "note"`, `note` 0–127, optional `velocity`
+  1–127 (defaults to 100).
+- **rests** – `type: "rest"` and `ticks`; any `note` or `velocity` fields are
+  ignored.
+- **channel** – optional; defaults to channel 1 when omitted or out of range.
+
+Sequences longer than 64 events are rejected to conserve memory on the UNO R4.
+
+## Using with Claude Desktop
+
+Update `claude_desktop_config.json` so Claude launches the bridge via stdio. An
+example entry is provided below (adjust the paths for your system):
+
+```json
+{
+  "mcpServers": {
+    "uno-r4-midi": {
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/uno_r4_mcp_bridge.py",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "UNO_R4_BASE_URL": "http://192.168.1.42"
+      },
+      "description": "Arduino UNO R4 WiFi MIDI player (FastMCP bridge)"
+    }
+  }
+}
+```
+
+Claude requires the `command` field even when using stdio. After saving the
+configuration, restart Claude Desktop. The MCP panel should list
+`uno-r4-midi` with the `load_sequence` and `get_status` tools available.
+
+## Typical workflow
+
+1. Flash the Arduino sketch and confirm it reports the correct IP address.
+2. Start `python uno_r4_mcp_bridge.py` and verify that it can reach the board by
+   calling `get_status` (either from Claude or via `mcp` CLI tooling).
+3. Have the AI agent invoke `load_sequence` with the desired phrase.
+4. Press the D4 button to arm playback. Once external MIDI clock pulses arrive,
+   the UNO will perform the uploaded notes in sync. Press D4 again to stop.
+5. Send a new `load_sequence` request whenever you want to change the material.
+
+## Troubleshooting
+
+- Ensure the UNO and the machine running the Python bridge are on the same
+  network; firewalls blocking port 80 will prevent uploads.
+- If the bridge reports connection errors, double-check `UNO_R4_BASE_URL` and
+  the Arduino's serial console output.
+- MIDI playback only starts after the board sees a MIDI `Start`/`Continue`
+  message and the D4 button has been pressed to arm playback.

--- a/claude_desktop_config.json
+++ b/claude_desktop_config.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "uno-r4-midi": {
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/uno_r4_mcp_bridge.py",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "UNO_R4_BASE_URL": "http://192.168.1.42"
+      },
+      "description": "Arduino UNO R4 WiFi MIDI player (FastMCP bridge)"
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastmcp>=2.12.3
+python-dotenv>=1.0
+httpx>=0.28

--- a/uno_r4_mcp_bridge.py
+++ b/uno_r4_mcp_bridge.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""FastMCP bridge that uploads MIDI sequences to an Arduino UNO R4 WiFi."""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import os
+import sys
+from typing import Annotated, Literal
+
+import httpx
+from dotenv import load_dotenv
+from fastmcp import Context, FastMCP
+from pydantic import (
+    BaseModel,
+    Field,
+    PositiveInt,
+    ValidationError,
+    conint,
+    model_validator,
+)
+
+DEFAULT_CHANNEL = 1
+MAX_EVENTS = 64
+DEFAULT_TIMEOUT = 5.0
+
+load_dotenv()
+
+
+class MidiEvent(BaseModel):
+    """Single step in a monophonic MIDI sequence."""
+
+    type: Literal["note", "rest"] = Field(
+        description="Event type. Use 'note' for sounding events or 'rest' for silence."
+    )
+    ticks: PositiveInt = Field(
+        description="Duration in MIDI clock ticks (24 ticks = quarter note)."
+    )
+    note: conint(ge=0, le=127) | None = Field(
+        default=None,
+        description="MIDI note number (0-127). Required when type='note'.",
+    )
+    velocity: conint(ge=1, le=127) | None = Field(
+        default=None,
+        description="MIDI velocity (1-127). Defaults to 100 when omitted for notes.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_note_fields(self) -> MidiEvent:  # type: ignore[override]
+        if self.type == "note":
+            if self.note is None:
+                raise ValueError("'note' is required when type is 'note'.")
+            if self.velocity is None:
+                self.velocity = 100
+        else:
+            # Ignore note-specific fields for rests
+            self.note = None
+            self.velocity = None
+        return self
+
+
+class LoadSequenceRequest(BaseModel):
+    """Validated payload sent to the Arduino controller."""
+
+    channel: conint(ge=1, le=16) = Field(
+        default=DEFAULT_CHANNEL,
+        description="MIDI channel (1-16) that the UNO should play on.",
+    )
+    sequence: list[MidiEvent] = Field(
+        min_length=1,
+        max_length=MAX_EVENTS,
+        description="Ordered list of note/rest events to buffer on the UNO.",
+    )
+
+
+class ArduinoBridge:
+    """Small HTTP client that talks to the UNO R4 REST API."""
+
+    def __init__(self, base_url: str, *, timeout: float = DEFAULT_TIMEOUT) -> None:
+        if not base_url.startswith("http://") and not base_url.startswith("https://"):
+            raise ValueError(
+                "arduino base URL must include the scheme, e.g. http://192.168.1.42"
+            )
+        self.base_url = base_url.rstrip("/")
+        self._client = httpx.Client(base_url=self.base_url, timeout=timeout)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def load_sequence(self, payload: LoadSequenceRequest) -> dict:
+        body = payload.model_dump(exclude_none=True)
+        try:
+            response = self._client.post("/sequence", json=body)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = exc.response.text.strip()
+            if exc.response.status_code == 400:
+                raise ValueError(
+                    f"Arduino rejected the sequence: {detail or exc}"
+                ) from exc
+            raise RuntimeError(
+                f"Arduino returned {exc.response.status_code} {exc.response.reason_phrase}: {detail or exc}"
+            ) from exc
+        except httpx.HTTPError as exc:  # network / timeout issues
+            raise RuntimeError(
+                f"Failed to contact Arduino at {self.base_url}: {exc}"
+            ) from exc
+        return response.json()
+
+    def get_status(self) -> dict:
+        try:
+            response = self._client.get("/status")
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Failed to query Arduino status: {exc}") from exc
+        return response.json()
+
+
+_bridge: ArduinoBridge | None = None
+
+
+def get_bridge() -> ArduinoBridge:
+    if _bridge is None:
+        raise RuntimeError(
+            "Arduino bridge has not been initialised. Call main() first."
+        )
+    return _bridge
+
+
+server = FastMCP(
+    name="uno-r4-midi-bridge",
+    version="0.2.0",
+    instructions=(
+        "Uploads MIDI note sequences to an Arduino UNO R4 WiFi over HTTP and"
+        " keeps track of its playback status."
+    ),
+)
+
+SequenceArg = Annotated[
+    list[MidiEvent],
+    Field(
+        description="Ordered list of note/rest events described in MIDI clock ticks.",
+        min_length=1,
+        max_length=MAX_EVENTS,
+    ),
+]
+ChannelArg = Annotated[
+    int,
+    Field(
+        ge=1,
+        le=16,
+        description="Target MIDI channel for playback (1-16).",
+        examples=[1],
+    ),
+]
+
+
+@server.tool(
+    description="Buffer a MIDI sequence on the Arduino for clock-synchronised playback."
+)
+def load_sequence(
+    sequence: SequenceArg,
+    channel: ChannelArg = DEFAULT_CHANNEL,
+    ctx: Context | None = None,
+) -> dict:
+    try:
+        request = LoadSequenceRequest(channel=channel, sequence=sequence)
+    except ValidationError as exc:
+        raise ValueError(str(exc)) from exc
+
+    if ctx is not None:
+        ctx.info(
+            f"Uploading {len(request.sequence)} events to {get_bridge().base_url} on channel {request.channel}."
+        )
+
+    result = get_bridge().load_sequence(request)
+    if ctx is not None:
+        ctx.debug(f"Arduino response: {result}")
+    return result
+
+
+@server.tool(description="Read the UNO's current transport and network status.")
+def get_status(ctx: Context | None = None) -> dict:
+    status = get_bridge().get_status()
+    if ctx is not None:
+        ctx.debug(f"Status: {status}")
+    return status
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--arduino-base-url",
+        default=os.environ.get("UNO_R4_BASE_URL"),
+        help="Base URL for the Arduino REST API (e.g. http://192.168.1.42).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("UNO_R4_TIMEOUT", DEFAULT_TIMEOUT)),
+        help="HTTP timeout when communicating with the Arduino (seconds).",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "streamable-http"],
+        default=os.environ.get("MCP_TRANSPORT", "stdio"),
+        help="Transport to expose to the MCP client.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    if not args.arduino_base_url:
+        print(
+            "Error: --arduino-base-url or UNO_R4_BASE_URL must be provided",
+            file=sys.stderr,
+        )
+        return 2
+
+    global _bridge
+    _bridge = ArduinoBridge(args.arduino_base_url, timeout=args.timeout)
+    atexit.register(_bridge.close)
+
+    server.run(transport=args.transport)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace the Arduino-hosted MCP implementation with a REST-focused sketch that accepts `/sequence` uploads and reports `/status`
- add a Python FastMCP bridge (`uno_r4_mcp_bridge.py`) that forwards MCP tool calls to the Arduino over HTTP and expose a status tool
- document the new architecture, setup steps, and sample Claude Desktop configuration plus add a `requirements.txt` for the bridge

## Testing
- python -m compileall uno_r4_mcp_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d6b72a608321899d673723afadaf